### PR TITLE
Add global install knex

### DIFF
--- a/S03E03.md
+++ b/S03E03.md
@@ -271,6 +271,7 @@ npm init .
 - ao final das perguntas, a pasta do projeto terá um arquivo chamado **package.json**
 
 ```bash
+npm install knex -g
 npm install knex --save
 npm install sqlite3 --save
 ```


### PR DESCRIPTION
Its wasn`t possible to exec "knex init" without installing globally.